### PR TITLE
Add testing for loading error favorites and openscroll components

### DIFF
--- a/src/Components/Error/Error.test.js
+++ b/src/Components/Error/Error.test.js
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+import Error from './Error/Error';
+import { shallow, mount } from 'enzyme';
+
+describe('Error component', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<Error />)
+  })
+
+  test('Error should exist', () => {
+    expect(wrapper).toBeDefined()
+  })
+
+  test('should render open scroll container', () => {
+    expect(wrapper.find('.error-container').length).toEqual(1)
+  })
+})

--- a/src/Components/Favorites/Favorites.test.js
+++ b/src/Components/Favorites/Favorites.test.js
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+import Favorites from './Favorites/Favorites';
+import { shallow, mount } from 'enzyme';
+
+describe('Favorites component', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<Favorites />)
+  })
+
+  test('Favorites should exist', () => {
+    expect(wrapper).toBeDefined()
+  })
+
+  test('should render open scroll container', () => {
+    expect(wrapper.find('.card-container').length).toEqual(1)
+  })
+})

--- a/src/Components/Loading/Loading.test.js
+++ b/src/Components/Loading/Loading.test.js
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+import Loading from './Loading/Loading';
+import { shallow, mount } from 'enzyme';
+
+describe('Load component', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<Loading />)
+  })
+
+  test('Loading should exist', () => {
+    expect(wrapper).toBeDefined()
+  })
+
+  test('should render loading container', () => {
+    expect(wrapper.find('.loading-container').length).toEqual(1)
+  })
+})

--- a/src/Components/OpenScroll/OpenScroll.test.js
+++ b/src/Components/OpenScroll/OpenScroll.test.js
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+import OpenScroll from './OpenScroll/OpenScroll';
+import { shallow, mount } from 'enzyme';
+
+describe('OpenScroll component', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<OpenScroll />)
+  })
+
+  test('OpenScroll should exist', () => {
+    expect(wrapper).toBeDefined()
+  })
+
+  test('should render open scroll container', () => {
+    expect(wrapper.find('.outer-container').length).toEqual(1)
+  })
+})


### PR DESCRIPTION
Add tests for loading, error, favorites, and openscroll components. Very basic, and have not been able to run tests.